### PR TITLE
feat(ios): add support for initially selected nodes #6

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,26 +174,27 @@ const App = () => {
 
 ### iOS Only Props
 
-| property          | type    | required | description                                                                                                                                    | default      |
-| ----------------- | ------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------- | ------------ |
-| id                | string  | TRUE     | A custom identifier used for identifying the node                                                                                              | -            |
-| text              | string  | TRUE     | The text of the bubble. **Note: on android the text must be unique**                                                                           | -            |
-| color             | string  | FALSE    | The background color of the bubble                                                                                                             | black        |
-| radius            | number  | FALSE    | The radius of the bubble. This value is ignored if autoSize is enabled                                                                         | 30           |
-| marginScale       | number  | FALSE    | The margin scale applied to the physics body of the bubble. **recommend that you do not change this value unless you know what you are doing** | 1.01         |
-| fontName          | string  | FALSE    | The name of the custom font applied to the bubble                                                                                              | Avenir-Black |
-| fontSize          | number  | FALSE    | The size of the custom font applied to the bubble                                                                                              | 13           |
-| fontColor         | string  | FALSE    | The color of the bubble text                                                                                                                   | white        |
-| lineHeight        | number  | FALSE    | The line height of the bubble. This value is ignored if autoSize is enabled                                                                    | 1.5          |
-| borderColor       | string  | FALSE    | The border color of the buble                                                                                                                  | -            |
-| borderWidth       | number  | FALSE    | The border width of the bubble                                                                                                                 | -            |
-| padding           | number  | FALSE    | Extra padding applied to the bubble contents, if autoSize is enabled                                                                           | 20           |
-| selectedScale     | number  | FALSE    | The scale of the selected bubble                                                                                                               | 1.33         |
-| deselectedScale   | number  | FALSE    | The scale of the deselected bubble                                                                                                             | 1            |
-| animationDuration | number  | FALSE    | The duration of the scale animation                                                                                                            | 0.2          |
-| selectedColor     | string  | FALSE    | The background color of the selected bubble                                                                                                    | -            |
-| selectedFontColor | string  | FALSE    | The color of the selected bubble text                                                                                                          | -            |
-| autoSize          | boolean | FALSE    | Whether or not the bubble should resize to fit its content                                                                                     | TRUE         |
+| property          | type     | required | description                                                                                                                                    | default      |
+| ----------------- | -------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------- | ------------ |
+| id                | string   | TRUE     | A custom identifier used for identifying the node                                                                                              | -            |
+| text              | string   | TRUE     | The text of the bubble. **Note: on android the text must be unique**                                                                           | -            |
+| color             | string   | FALSE    | The background color of the bubble                                                                                                             | black        |
+| radius            | number   | FALSE    | The radius of the bubble. This value is ignored if autoSize is enabled                                                                         | 30           |
+| marginScale       | number   | FALSE    | The margin scale applied to the physics body of the bubble. **recommend that you do not change this value unless you know what you are doing** | 1.01         |
+| fontName          | string   | FALSE    | The name of the custom font applied to the bubble                                                                                              | Avenir-Black |
+| fontSize          | number   | FALSE    | The size of the custom font applied to the bubble                                                                                              | 13           |
+| fontColor         | string   | FALSE    | The color of the bubble text                                                                                                                   | white        |
+| lineHeight        | number   | FALSE    | The line height of the bubble. This value is ignored if autoSize is enabled                                                                    | 1.5          |
+| borderColor       | string   | FALSE    | The border color of the buble                                                                                                                  | -            |
+| borderWidth       | number   | FALSE    | The border width of the bubble                                                                                                                 | -            |
+| padding           | number   | FALSE    | Extra padding applied to the bubble contents, if autoSize is enabled                                                                           | 20           |
+| selectedScale     | number   | FALSE    | The scale of the selected bubble                                                                                                               | 1.33         |
+| deselectedScale   | number   | FALSE    | The scale of the deselected bubble                                                                                                             | 1            |
+| animationDuration | number   | FALSE    | The duration of the scale animation                                                                                                            | 0.2          |
+| selectedColor     | string   | FALSE    | The background color of the selected bubble                                                                                                    | -            |
+| selectedFontColor | string   | FALSE    | The color of the selected bubble text                                                                                                          | -            |
+| autoSize          | boolean  | FALSE    | Whether or not the bubble should resize to fit its content                                                                                     | TRUE         |
+| initialSelection  | string[] | FALSE    | An id array of the initially selected nodes                                                                                                    | -            |
 
 ### Android Only Props
 

--- a/ios/Magnetic/Magnetic.swift
+++ b/ios/Magnetic/Magnetic.swift
@@ -42,19 +42,26 @@ import SpriteKit
     open var longPressDuration: TimeInterval = 0.35
     
     open var isDragging: Bool = false
-    
+  
+    /**
+   Returns the magnetic nodes
+   */
+    open var nodes: [Node] {
+        return children.compactMap { $0 as? Node }
+    }
+  
     /**
      The selected children.
      */
     open var selectedChildren: [Node] {
-        return children.compactMap { $0 as? Node }.filter { $0.isSelected }
+        return nodes.filter { $0.isSelected }
     }
     
     /**
      The removed children.
      */
     open var removedChildren: [Node] {
-        return children.compactMap { $0 as? Node }.filter { $0.isRemoved }
+        return nodes.filter { $0.isRemoved }
     }
     
     /**

--- a/ios/Magnetic/Node.swift
+++ b/ios/Magnetic/Node.swift
@@ -261,7 +261,7 @@ import SpriteKit
             super.removeFromParent()
         }
     }
-    
+  
     /**
      Resizes the node to fit its current content
      */

--- a/ios/RNBubbleMagneticView.swift
+++ b/ios/RNBubbleMagneticView.swift
@@ -37,6 +37,14 @@ class RNBubbleMagneticView: UIView {
     }
   }
   
+  var initialSelection: [String] = [] {
+    didSet {
+      magnetic.nodes.filter {
+        self.initialSelection.contains($0.id)
+      }.forEach { $0.isSelected = true }
+    }
+  }
+  
   var onSelect: RCTDirectEventBlock?
   var onDeselect: RCTDirectEventBlock?
   var onRemove: RCTDirectEventBlock?
@@ -109,6 +117,10 @@ extension RNBubbleMagneticView {
   
   @objc func setMagneticBackgroundColor(_ magneticBackgroundColor: UIColor?) {
     self.magneticBackgroundColor = magneticBackgroundColor ?? .white
+  }
+  
+  @objc func setInitialSelection(_ initialSelection: [String]) {
+    self.initialSelection = initialSelection ?? []
   }
 }
 

--- a/ios/RNBubbleSelectViewManager.m
+++ b/ios/RNBubbleSelectViewManager.m
@@ -18,5 +18,6 @@ RCT_EXPORT_VIEW_PROPERTY(allowsMultipleSelection, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(longPressDuration, CGFloat)
 RCT_EXPORT_VIEW_PROPERTY(removeNodeOnLongPress, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(magneticBackgroundColor, UIColor)
+RCT_EXPORT_VIEW_PROPERTY(initialSelection, NSArray*)
 
 @end

--- a/src/BubbleSelect.tsx
+++ b/src/BubbleSelect.tsx
@@ -22,6 +22,7 @@ export type BubbleSelectProps = Omit<BubbleProps, 'text' | 'id'> & {
   longPressDuration?: number;
   backgroundColor?: string;
   maxSelectedItems?: number;
+  initialSelection?: string[];
 };
 
 const BubbleSelect = ({
@@ -38,6 +39,7 @@ const BubbleSelect = ({
   height = 200,
   backgroundColor,
   maxSelectedItems,
+  initialSelection = [],
   ...bubbleProps
 }: BubbleSelectProps) => {
   const defaultStyle = {
@@ -64,7 +66,7 @@ const BubbleSelect = ({
     }
   };
 
-  const androidProps = Platform.select({
+  const platformProps = Platform.select({
     android: {
       onSelectNode: handleSelect,
       onDeselectNode: handleDeselect,
@@ -72,6 +74,9 @@ const BubbleSelect = ({
       bubbleSize,
       backgroundColor,
       maxSelectedItems,
+    },
+    ios: {
+      initialSelection,
     },
     default: {},
   });
@@ -86,7 +91,7 @@ const BubbleSelect = ({
       removeNodeOnLongPress={removeOnLongPress}
       longPressDuration={longPressDuration}
       magneticBackgroundColor={backgroundColor}
-      {...androidProps}
+      {...platformProps}
     >
       {React.Children.map(children, (child: any) =>
         React.cloneElement(child, bubbleProps)


### PR DESCRIPTION
This feature currently only works for iOS. I'll wait for @canpoyrazoglu to try it out before merging the code into master and releasing a new version.

I'll start looking into the android implementation of this also.